### PR TITLE
Twitter4Dの引数を連想配列から文字列へ変更

### DIFF
--- a/source/test.d
+++ b/source/test.d
@@ -4,11 +4,11 @@ import std.stdio,
        std.conv,
        std.regex;
 void main(){
-  Twitter4D t4d = new Twitter4D([
-      "consumerKey"       : "Your Consumer Key",
-      "consumerSecret"    : "Your Consumer Secret",
-      "accessToken"       : "Your Access Token" ,
-      "accessTokenSecret" : "Your Access Token Secret"]);
+  Twitter4D t4d = new Twitter4D(
+    "Your Consumer Key",
+    "Your Consumer Secret",
+    "Your Access Token" ,
+    "Your Access Token Secret");
 
   writeln(t4d.request("POST", "statuses/update.json", ["status" : "test"]));
   writeln(parseJSON(t4d.request("GET", "account/verify_credentials.json", ["":""])));

--- a/source/twitter4d.d
+++ b/source/twitter4d.d
@@ -26,14 +26,11 @@ class Twitter4D{
     string baseUrl = "https://api.twitter.com/1.1/";
   }
 
-  this(string[string] oauthHash){
-    if(oauthHash.length < 4)
-      throw new Error("Error: When Initialize this class, requirements 4 element");
-
-    consumerKey       = oauthHash["consumerKey"];
-    consumerSecret    = oauthHash["consumerSecret"];
-    accessToken       = oauthHash["accessToken"];
-    accessTokenSecret = oauthHash["accessTokenSecret"];
+  this(string consumerKey, string consumerSecret, string accessToken, string accessTokenSecret){
+    this.consumerKey       = consumerKey;
+    this.consumerSecret    = consumerSecret;
+    this.accessToken       = accessToken;
+    this.accessTokenSecret = accessTokenSecret;
   }
 
 


### PR DESCRIPTION
Twitter4Dのコンストラクタの引数として連想配列が使われていますが、連想配列だと実行時でなければ要素数が判断出来なかったり、consumerKeyなどのキーが存在するか分からないので、引数としてそれぞれの文字列を取った方がいいんじゃないでしょうか。
accessToken, accessTokenSecretが無かった場合に取得するコンストラクタとかも書けますし。
