### PR TITLE
requestメソッドの引数paramsArgumentにデフォルト値を設定

### DIFF
--- a/source/twitter4d.d
+++ b/source/twitter4d.d
@@ -46,7 +46,7 @@ class Twitter4D{
 
   // post/get request function
   // Ex: request("POST", "statuses/update.json" ["status": "hoge"]);
-  auto request(string type, string endPoint, string[string] paramsArgument){
+  auto request(string type, string endPoint, string[string] paramsArgument = ["":""]){
     string method = (){
       if(type == "get" || type == "GET")
         return "GET";


### PR DESCRIPTION
パラメータ要らない場合もあるのでデフォルトで空の連想配列が設定されてる方が楽な気がします。
