### PR TITLE
Build with ldc

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,5 +6,6 @@
     "copyright": "Copyright (C) 2014 alphaKAI",
     "license": "MIT",
     "libs": ["curl"],
-    "excludedSourceFiles": ["source/test.d"]
+    "excludedSourceFiles": ["source/test.d"],
+    "dflags-ldc":["-disable-linker-strip-dead"]
 }


### PR DESCRIPTION
Building with ldc has shown the following error.
```
$dub run --compiler=ldc2
Performing "debug" build using ldc2 for x86_64.
twitter4d 0.0.66: building configuration "library"...
twitter4d-test ~master: building configuration "application"...
Running ./twitter4d-test 
Fatal Error while loading '/usr/lib/libphobos2-ldc.so.70':
	The module 'std.base64' is already defined in './twitter4d-test'.
Program exited with code 1
```

This PR specifying `"dflags-ldc":["-disable-linker-strip-dead"]` will fix it.