### PR TITLE
added additional parameter to stream().

### DIFF
--- a/source/twitter4d.d
+++ b/source/twitter4d.d
@@ -139,8 +139,8 @@ class Twitter4D {
     return null;
   }
 
-  public auto stream(string url = "https://userstream.twitter.com/1.1/user.json") {
-    string[string] params = buildParams();
+  public auto stream(string url = "https://userstream.twitter.com/1.1/user.json", string[string] additionalParam = null) {
+    string[string] params = buildParams(additionalParam);
 
     string oauthSignature = signature(consumerSecret, accessTokenSecret, "GET", url, params);
     params["oauth_signature"] = oauthSignature;


### PR DESCRIPTION
Twitter Userstream filter API has "keyword filtering parametes".
(https://developer.twitter.com/en/docs/twitter-api/v1/tweets/filter-realtime/api-reference/post-statuses-filter)

I need "track" parameter, but stream() method not have that optional parameter.
This worked, is that okay?